### PR TITLE
I112 public events get route

### DIFF
--- a/middlewares/validators/zod-schemas/events.ts
+++ b/middlewares/validators/zod-schemas/events.ts
@@ -13,6 +13,7 @@ const postEventSchema = z.object({
       endTime: z.number(),
       calendarId: z.number(),
       attendees: z.array(z.string()).optional(),
+      isPrivate: z.boolean(),
       // TODO: Recuring event to be added
     })
     .strict(),
@@ -32,6 +33,7 @@ const patchEventSchema = z.object({
       endTime: z.number().optional(),
       calendarId: z.number().optional(),
       attendees: z.array(z.string()).optional(),
+      isPrivate: z.boolean(),
       // TODO: Recuring event to be added
     })
     .strict(),
@@ -53,9 +55,17 @@ const getCalenderEventSchema = z.object({
   }),
 });
 
+const getPublicEventSchema = z.object({
+  query: z.object({
+    startTime: z.preprocess((a) => Number(a), z.number().positive()).optional(),
+    endTime: z.preprocess((a) => Number(a), z.number().positive()).optional(),
+  }),
+});
+
 export {
   postEventSchema,
   patchEventSchema,
   getEventSchema,
   getCalenderEventSchema,
+  getPublicEventSchema,
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model Event {
   EventType      EventType?       @relation(fields: [eventTypeId], references: [id])
   calendarId     Int
   Calendar       Calendar?        @relation(fields: [calendarId], references: [id])
+  isPrivate      Boolean          @default(true)
   isDeleted      Boolean          @default(false)
   RecurringEvent RecurringEvent[]
   Attendees      Attendees[]

--- a/routes/events.ts
+++ b/routes/events.ts
@@ -4,6 +4,7 @@ import {
   getEvents,
   postEvent,
   patchEvent,
+  getPublicEvents,
 } from '../controllers/events';
 import authenticate from '../middlewares/authenticate';
 import { validate } from '../middlewares/validators/validator';
@@ -12,6 +13,7 @@ import {
   getEventSchema,
   postEventSchema,
   patchEventSchema,
+  getPublicEventSchema,
 } from '../middlewares/validators/zod-schemas/events';
 import {
   calendarBelongsToUser,
@@ -21,6 +23,7 @@ import {
 const router = Router();
 
 /* eslint-disable @typescript-eslint/no-misused-promises */
+router.get('/', authenticate, validate(getPublicEventSchema), getPublicEvents);
 router.post(
   '/',
   authenticate,
@@ -49,6 +52,7 @@ router.get(
   calendarBelongsToUser,
   getCalendarEvents
 );
+
 /* eslint-disable @typescript-eslint/no-misused-promises */
 
 export default router;

--- a/services/eventsService.ts
+++ b/services/eventsService.ts
@@ -70,6 +70,44 @@ const findEventFromCalendar = async (
   }
 };
 
+const findPublicEvent = async (
+  startTime: number,
+  endTime: number
+): Promise<eventWithAttendees[]> => {
+  try {
+    const whereCondition: {} = {
+      isDeleted: false,
+      isPrivate: false,
+      ...(startTime && { startTime: { gte: new Date(startTime) } }),
+      ...(endTime && { endTime: { lte: new Date(endTime) } }),
+    };
+
+    // TODO: add pagination
+
+    const event: eventWithAttendees[] = await prisma.event.findMany({
+      where: whereCondition,
+      include: {
+        Attendees: {
+          select: {
+            attendee: {
+              select: {
+                email: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return event;
+  } catch (err) {
+    logger.error('parentEvent: error while finding parent event', {
+      err,
+    });
+    throw err;
+  }
+};
+
 const findCalendarWithId = async (
   calendarId: number
 ): Promise<Calendar | null> => {
@@ -89,6 +127,7 @@ const findEventWithId = async (eventId: number): Promise<Event | null> => {
 export {
   findEvent,
   findEventFromCalendar,
+  findPublicEvent,
   findCalendarWithId,
   findEventWithId,
 };


### PR DESCRIPTION
Added `isPrivate` key for events, in db schema

Added `/events` route, which gets the all users public events


<img width="1173" alt="image" src="https://github.com/Real-Dev-Squad/calendar-API/assets/34452139/7404c521-b1d9-4b26-9a1c-2287ad399caa">
